### PR TITLE
fixed deprecated groupby call from pandas

### DIFF
--- a/harmoniQ/harmoniq/modules/reseau/__init__.py
+++ b/harmoniQ/harmoniq/modules/reseau/__init__.py
@@ -326,9 +326,11 @@ class InfraReseau(Infrastructure):
             "Pmax_calcule": Pmax,
             "niveaux_reservoirs": niveaux_reservoirs,
             "optimization_results": optimization_results,
-            "production_par_type": optimized_network.generators_t['p'].groupby(
-                optimized_network.generators.carrier, axis=1
-            ).sum(),
+            "production_par_type": optimized_network.generators_t['p']
+            .T
+            .groupby(optimized_network.generators.carrier)
+            .sum()
+            .T,
             "energie_importee": optimized_network.generators_t['p'].get(f"import_{bus_frontiere}", pd.Series()).sum() 
                 if f"import_{bus_frontiere}" in optimized_network.generators_t['p'].columns else 0,
             "energie_exportee": optimized_network.loads_t['p'].get(f"export_{bus_frontiere}", pd.Series()).sum() 

--- a/harmoniQ/harmoniq/modules/reseau/core/optimization.py
+++ b/harmoniQ/harmoniq/modules/reseau/core/optimization.py
@@ -539,9 +539,11 @@ class NetworkOptimizer:
             "total_cost": float(total_cost),
             "pilotable_production": self.network.generators_t['p'][pilotable_gens].sum().sum(),
             "non_pilotable_production": self.network.generators_t['p'][non_pilotable_gens].sum().sum(),
-            "production_by_type": self.network.generators_t['p'].groupby(
-                self.network.generators.carrier, axis=1
-            ).sum(),
+            "production_by_type": self.network.generators_t['p']
+            .T
+            .groupby(self.network.generators.carrier)
+            .sum()
+            .T,
             "line_loading_max": self.network.lines_t['p0'].abs().max(),
             "n_active_line_constraints": (
                 self.network.lines_t['p0'].abs() > 0.99 * self.network.lines.s_nom


### PR DESCRIPTION
groupby axis=1 call not supported in current pandas version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal data processing logic for production calculations in optimization modules to improve code structure and data handling consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->