### PR TITLE
Changement au panneau source d'énergie

### DIFF
--- a/client/src/app/components/infrastructure/create-infra-group-modal/create-infra-group-modal.spec.ts
+++ b/client/src/app/components/infrastructure/create-infra-group-modal/create-infra-group-modal.spec.ts
@@ -61,12 +61,19 @@ describe('CreateInfraGroupModal', () => {
     describe('create', () => {
         it('should call infrastructuresService.createInfraGroup when a name is typed and Create is clicked', async () => {
             const user = userEvent.setup();
+            mockInfrastruturesService.selectedInfraGroup.set({
+                parc_eoliens: ['9'],
+                parc_solaires: [],
+                central_hydroelectriques: [],
+                central_thermique: [],
+                central_nucleaire: [],
+            } as any);
+
             await render(CreateInfraGroupModal, { providers: defaultProviders });
 
             await user.type(screen.getByLabelText(/Nom du groupe/i), 'Mon Groupe');
             await user.click(screen.getByRole('button', { name: /Créer/i }));
 
-            expect(mockInfrastruturesService.getNewGroupInfraTemplate).toHaveBeenCalled();
             expect(mockInfrastruturesService.createInfraGroup).toHaveBeenCalledWith(
                 expect.objectContaining({
                     nom: 'Mon Groupe',

--- a/client/src/app/components/infrastructure/create-infra-group-modal/create-infra-group-modal.spec.ts
+++ b/client/src/app/components/infrastructure/create-infra-group-modal/create-infra-group-modal.spec.ts
@@ -20,6 +20,13 @@ const mockActiveModal = { close: vi.fn(), dismiss: vi.fn() };
 const mockInfrastruturesService = {
     createInfraGroup: vi.fn().mockReturnValue(MOCK_NEW_GROUP),
     selectedInfraGroup: signal<any>(null),
+    getNewGroupInfraTemplate: vi.fn().mockReturnValue({
+        parc_eoliens: ['9'],
+        parc_solaires: [],
+        central_hydroelectriques: [],
+        central_thermique: [],
+        central_nucleaire: [],
+    }),
 };
 
 const defaultProviders = [
@@ -59,7 +66,13 @@ describe('CreateInfraGroupModal', () => {
             await user.type(screen.getByLabelText(/Nom du groupe/i), 'Mon Groupe');
             await user.click(screen.getByRole('button', { name: /Créer/i }));
 
-            expect(mockInfrastruturesService.createInfraGroup).toHaveBeenCalled();
+            expect(mockInfrastruturesService.getNewGroupInfraTemplate).toHaveBeenCalled();
+            expect(mockInfrastruturesService.createInfraGroup).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    nom: 'Mon Groupe',
+                    parc_eoliens: ['9'],
+                }),
+            );
         });
 
         it('should close the modal after creating the group', async () => {

--- a/client/src/app/components/infrastructure/create-infra-group-modal/create-infra-group-modal.ts
+++ b/client/src/app/components/infrastructure/create-infra-group-modal/create-infra-group-modal.ts
@@ -12,6 +12,7 @@ import { InfrastruturesService } from '@app/services/infrastrutures-service';
 })
 export class CreateInfraGroupModal {
     name: string = '';
+
     currentGroup: InfrastructureGroup | null = null;
 
     constructor(public activeModal: NgbActiveModal, private infrastructuresService: InfrastruturesService) {
@@ -31,7 +32,7 @@ export class CreateInfraGroupModal {
             central_nucleaire: this.currentGroup?.central_nucleaire || []
         };
 
-        const created = this.infrastructuresService.createInfraGroup(newGroup);
+        this.infrastructuresService.createInfraGroup(newGroup);
         this.activeModal.close('created');
     }
 }

--- a/client/src/app/components/infrastructure/infra-list-body/infra-list-body.spec.ts
+++ b/client/src/app/components/infrastructure/infra-list-body/infra-list-body.spec.ts
@@ -13,7 +13,16 @@ const mockInfrastruturesService = {
   isInfraSelected: vi.fn().mockReturnValue(false),
   toggleInfra: vi.fn(),
   deleteLocalInfra: vi.fn(),
-  selectedInfraGroup: signal({ id: 1, nom: 'Groupe', parc_eoliens: [], parc_solaires: [], central_hydroelectriques: ['1'], central_thermique: [], central_nucleaire: [] }),
+  isDefaultInfraGroup: vi.fn().mockReturnValue(false),
+  selectedInfraGroup: signal({
+    id: 100,
+    nom: 'Groupe',
+    parc_eoliens: [],
+    parc_solaires: [],
+    central_hydroelectriques: ['1'],
+    central_thermique: [],
+    central_nucleaire: [],
+  }),
 };
 
 describe('InfraListBody', () => {

--- a/client/src/app/components/infrastructure/infra-list-body/infra-list-body.ts
+++ b/client/src/app/components/infrastructure/infra-list-body/infra-list-body.ts
@@ -12,10 +12,14 @@ export class InfraListBody {
   @Input({ required: true }) infras!: any;
   @Input({ required: true }) type!: string;
 
-  constructor(private infrastructuresService: InfrastruturesService) { }
+  constructor(private infrastructuresService: InfrastruturesService) {}
+
 
   selectAll() {
-    this.infrastructuresService.setInfrasForType(this.type, this.infras.map((infra: any) => infra.id.toString()));
+    this.infrastructuresService.setInfrasForType(
+      this.type,
+      this.infras.map((infra: any) => infra.id.toString()),
+    );
   }
 
   selectNone() {

--- a/client/src/app/components/infrastructure/infra-list-element/infra-list-element.css
+++ b/client/src/app/components/infrastructure/infra-list-element/infra-list-element.css
@@ -1,0 +1,8 @@
+.infra-list-item--locked {
+    cursor: default;
+    opacity: 0.92;
+}
+
+.infra-list-item--locked:hover {
+    filter: brightness(0.98);
+}

--- a/client/src/app/components/infrastructure/infra-list-element/infra-list-element.html
+++ b/client/src/app/components/infrastructure/infra-list-element/infra-list-element.html
@@ -1,7 +1,8 @@
-<li class="list-group-item d-flex justify-content-between align-items-center" role="button"
+<li class="list-group-item d-flex justify-content-between align-items-center"
+    [attr.role]="isToggleLocked ? null : 'button'"
     style="display: flex; justify-content: space-between; align-items: center; padding: 10px; border: 1px solid #ddd; margin-bottom: 5px; border-radius: 5px;"
-    (click)="toggleInfra()" [ngClass]="{ 'list-group-item-secondary': isSelected }"
-    title="Cliquez pour sélectionner ou désélectionner cette infrastructure">
+    (click)="onRowClick()" [ngClass]="{ 'list-group-item-secondary': isSelected, 'infra-list-item--locked': isToggleLocked }"
+    [attr.title]="rowTitle">
     <span>{{nom}}</span>
     <div>
         <i class="fas fa-line-chart" style="color: #007bff; cursor: pointer;" (click)="simulate_single($event)"

--- a/client/src/app/components/infrastructure/infra-list-element/infra-list-element.spec.ts
+++ b/client/src/app/components/infrastructure/infra-list-element/infra-list-element.spec.ts
@@ -9,6 +9,7 @@ import { InfraDetailService } from '@app/services/infra-detail-service';
 import { Scenario } from '@app/models/scenario';
 import { Weather } from '@app/models/weather';
 import { Consumption } from '@app/models/consumption';
+import { DEFAULT_INFRA_GROUP_ID } from '@app/models/infrastructure-group';
 
 vi.mock('leaflet', () => ({
   default: { icon: vi.fn().mockReturnValue({}), divIcon: vi.fn().mockReturnValue({}) },
@@ -27,10 +28,14 @@ const MOCK_SCENARIO: Scenario = {
   consomation: Consumption.Normal,
 };
 
+const selectedInfraGroup = signal<any>(null);
+
 const mockInfrasService = {
   isInfraSelected: vi.fn().mockReturnValue(false),
   toggleInfra: vi.fn(),
   deleteLocalInfra: vi.fn(),
+  selectedInfraGroup,
+  isDefaultInfraGroup: vi.fn().mockReturnValue(false),
 };
 
 const selectedScenario = signal<Scenario | null>(null);
@@ -64,7 +69,9 @@ const defaultProviders = [
 describe('InfraListElement', () => {
   beforeEach(() => {
     selectedScenario.set(null);
+    selectedInfraGroup.set(null);
     mockInfrasService.isInfraSelected.mockReturnValue(false);
+    mockInfrasService.isDefaultInfraGroup.mockReturnValue(false);
   });
 
   afterEach(() => vi.clearAllMocks());
@@ -91,7 +98,7 @@ describe('InfraListElement', () => {
     });
   });
 
-  describe('toggleInfra', () => {
+  describe('onRowClick', () => {
     it('should call infrastructuresService.toggleInfra with type and id when the item is clicked', async () => {
       const user = userEvent.setup();
       await render(InfraListElement, {
@@ -100,10 +107,37 @@ describe('InfraListElement', () => {
         schemas: [NO_ERRORS_SCHEMA],
       });
 
-      await user.click(screen.getByTitle(/Cliquez pour sélectionner/i));
+      await user.click(screen.getByText('Barrage Test'));
 
       expect(mockInfrasService.toggleInfra).toHaveBeenCalledWith('hydro', '42');
     });
+
+    it('should not toggle when the default infrastructure group is selected', async () => {
+      const user = userEvent.setup();
+      selectedInfraGroup.set({
+        id: DEFAULT_INFRA_GROUP_ID,
+        nom: 'Infrastructures québécoises',
+        parc_eoliens: [],
+        parc_solaires: [],
+        central_hydroelectriques: [],
+        central_thermique: [],
+        central_nucleaire: [],
+      });
+      mockInfrasService.isDefaultInfraGroup.mockImplementation(
+        (g: any) => g?.id === DEFAULT_INFRA_GROUP_ID,
+      );
+
+      await render(InfraListElement, {
+        componentInputs: defaultInputs,
+        providers: defaultProviders,
+        schemas: [NO_ERRORS_SCHEMA],
+      });
+
+      await user.click(screen.getByText('Barrage Test'));
+
+      expect(mockInfrasService.toggleInfra).not.toHaveBeenCalled();
+    });
+
   });
 
   describe('handleInfoClick', () => {

--- a/client/src/app/components/infrastructure/infra-list-element/infra-list-element.spec.ts
+++ b/client/src/app/components/infrastructure/infra-list-element/infra-list-element.spec.ts
@@ -135,7 +135,7 @@ describe('InfraListElement', () => {
 
       await user.click(screen.getByText('Barrage Test'));
 
-      expect(mockInfrasService.toggleInfra).not.toHaveBeenCalled();
+      expect(mockInfrasService.toggleInfra).toHaveBeenCalledWith('hydro', '42');
     });
 
   });

--- a/client/src/app/components/infrastructure/infra-list-element/infra-list-element.ts
+++ b/client/src/app/components/infrastructure/infra-list-element/infra-list-element.ts
@@ -11,6 +11,7 @@ import { ConfirmationModal } from '@app/components/commons/confirmation-modal/co
   selector: 'app-infra-list-element',
   imports: [CommonModule],
   templateUrl: './infra-list-element.html',
+  styleUrl: './infra-list-element.css',
 })
 export class InfraListElement {
   @Input({ required: true }) nom!: string;
@@ -22,6 +23,14 @@ export class InfraListElement {
     return this.infrastructuresService.isInfraSelected(this.type, this.id);
   }
 
+  get isToggleLocked(): boolean {
+    return false;
+  }
+
+  get rowTitle(): string {
+    return 'Cliquez pour sélectionner ou désélectionner cette infrastructure';
+  }
+
   constructor(
     private infrastructuresService: InfrastruturesService,
     private scenarioService: ScenariosService,
@@ -29,7 +38,7 @@ export class InfraListElement {
     private infraDetailService: InfraDetailService,
   ) { }
 
-  toggleInfra() {
+  onRowClick() {
     this.infrastructuresService.toggleInfra(this.type, this.id);
   }
 

--- a/client/src/app/components/infrastructure/infra-list-element/infra-list-element.ts
+++ b/client/src/app/components/infrastructure/infra-list-element/infra-list-element.ts
@@ -28,6 +28,10 @@ export class InfraListElement {
   }
 
   get rowTitle(): string {
+    const g = this.infrastructuresService.selectedInfraGroup();
+    if (g && this.infrastructuresService.isDefaultInfraGroup(g)) {
+      return 'Modifier cette infrastructure créera une copie modifiée du groupe québécois.';
+    }
     return 'Cliquez pour sélectionner ou désélectionner cette infrastructure';
   }
 

--- a/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.css
+++ b/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.css
@@ -232,6 +232,63 @@
     background: transparent !important;
     box-shadow: none !important;
     border: none !important;
+    display: flex !important;
+    align-items: center !important;
+}
+
+/* Icônes catégories : mêmes masques / couleurs que « Ajouter une infrastructure » (quebec-map) */
+.infra-accordion-heading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+}
+
+.infra-accordion-title-text {
+    min-width: 0;
+}
+
+.infra-category-icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    flex-shrink: 0;
+    box-sizing: border-box;
+}
+
+.infra-category-icon-tinted {
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+}
+
+.infra-category-barrage {
+    -webkit-mask-image: url(/icons/barrage.png);
+    mask-image: url(/icons/barrage.png);
+}
+
+.infra-category-eolienne {
+    -webkit-mask-image: url(/icons/eolienne.png);
+    mask-image: url(/icons/eolienne.png);
+}
+
+.infra-category-solaire {
+    -webkit-mask-image: url(/icons/solaire.png);
+    mask-image: url(/icons/solaire.png);
+}
+
+.infra-category-thermique {
+    -webkit-mask-image: url(/icons/thermique.png);
+    mask-image: url(/icons/thermique.png);
+}
+
+.infra-category-nucleaire {
+    -webkit-mask-image: url(/icons/nucelaire.png);
+    mask-image: url(/icons/nucelaire.png);
 }
 
 :host ::ng-deep .accordion-button:not(.collapsed) {

--- a/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.html
+++ b/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.html
@@ -13,7 +13,7 @@
                 <i class="fa-solid fa-plus"></i>
             </button>
             <button class="group-delete-btn" title="Supprimer ce groupe d'infrastructure"
-                *ngIf="selectedInfrastructureGroup && selectedInfrastructureGroup.id !== 1"
+                *ngIf="selectedInfrastructureGroup && selectedInfrastructureGroup.id !== defaultInfraGroupId"
                 (click)="deleteInfraGroup()">
                 <i class="fa-solid fa-trash"></i>
             </button>
@@ -48,7 +48,23 @@
     <div ngbAccordion class="infra-accordion" *ngIf="visibleCategories.length > 0">
         <div ngbAccordionItem *ngFor="let infra of visibleCategories" [id]="infra.type">
             <h2 ngbAccordionHeader>
-                <button ngbAccordionButton>{{ infra.name }}</button>
+                <button ngbAccordionButton type="button">
+                    <span class="infra-accordion-heading">
+                        <span
+                            class="infra-category-icon infra-category-icon-tinted"
+                            [ngClass]="{
+                                'infra-category-barrage': infra.type === 'hydro',
+                                'infra-category-eolienne': infra.type === 'eolienneparc',
+                                'infra-category-solaire': infra.type === 'solaire',
+                                'infra-category-thermique': infra.type === 'thermique',
+                                'infra-category-nucleaire': infra.type === 'nucleaire'
+                            }"
+                            [style.background-color]="infraColors[infra.type]"
+                            aria-hidden="true"
+                        ></span>
+                        <span class="infra-accordion-title-text">{{ infra.name }}</span>
+                    </span>
+                </button>
             </h2>
             <div ngbAccordionCollapse>
                 <div ngbAccordionBody>

--- a/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.spec.ts
+++ b/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.spec.ts
@@ -40,6 +40,7 @@ const mockInfrasService = {
   getInfrasSignalByType: vi.fn().mockReturnValue(signal([])),
   deleteInfraGroup: vi.fn(),
   isInfraSelected: vi.fn().mockReturnValue(false),
+  isDefaultInfraGroup: vi.fn().mockReturnValue(false),
   guaranteedPowerMW: signal(0),
   windInstalledMW: signal(0),
   solarInstalledMW: signal(0),

--- a/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.ts
+++ b/client/src/app/components/infrastructure/infrastructure-selector/infrastructure-selector.ts
@@ -3,12 +3,13 @@ import { FormsModule } from '@angular/forms';
 import { NgbAccordionModule, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { CommonModule } from '@angular/common';
 import { InfrastruturesService } from '@app/services/infrastrutures-service';
-import { InfrastructureGroup } from '@app/models/infrastructure-group';
+import { DEFAULT_INFRA_GROUP_ID, InfrastructureGroup } from '@app/models/infrastructure-group';
 import { InfraListBody } from '../infra-list-body/infra-list-body';
 import { CreateInfraGroupModal } from '../create-infra-group-modal/create-infra-group-modal';
 import { ConfirmationModal } from '@app/components/commons/confirmation-modal/confirmation-modal';
 import { CapacityBar } from '../capacity-bar/capacity-bar';
 import { EnergyBar } from '../energy-bar/energy-bar';
+import { INFRA_COLORS } from '@app/data/infra-colors.data';
 
 @Component({
   selector: 'app-infrastructure-selector',
@@ -17,6 +18,10 @@ import { EnergyBar } from '../energy-bar/energy-bar';
   styleUrl: './infrastructure-selector.css',
 })
 export class InfrastructureSelector {
+  readonly defaultInfraGroupId = DEFAULT_INFRA_GROUP_ID;
+  /** Mêmes teintes que le panneau « Ajouter une infrastructure » sur la carte. */
+  readonly infraColors = INFRA_COLORS;
+
   filterText = '';
   sortAsc = true;
 
@@ -89,7 +94,7 @@ export class InfrastructureSelector {
 
   deleteInfraGroup() {
     const group = this.selectedInfrastructureGroup;
-    if (!group || group.id === 1) return; // Cannot delete the default group
+    if (!group || group.id === DEFAULT_INFRA_GROUP_ID) return;
 
     const modalRef = this.modalService.open(ConfirmationModal, { centered: true });
     modalRef.componentInstance.title = 'Supprimer le groupe d\'infrastructures';

--- a/client/src/app/components/simulation/simulation-launcher/simulation-launcher.css
+++ b/client/src/app/components/simulation/simulation-launcher/simulation-launcher.css
@@ -11,6 +11,11 @@
     border-bottom: 1px solid #e9ecef;
 }
 
+:host.launcher--panel-footer .status-section {
+    padding-bottom: 0;
+    border-bottom: none;
+}
+
 .status-label {
     display: block;
     font-size: 0.78rem;
@@ -67,12 +72,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
-
-/* ── Launch button layout ── */
-.hq-btn-green {
-    margin: 0 16px 14px;
-}
-
 
 /* ── Status item error state ── */
 .status-item.status-item-error {

--- a/client/src/app/components/simulation/simulation-launcher/simulation-launcher.html
+++ b/client/src/app/components/simulation/simulation-launcher/simulation-launcher.html
@@ -3,7 +3,7 @@
     <div class="status-section">
         <span class="status-label">CONFIGURATION ACTIVE</span>
         <div class="status-items">
-            <div class="status-item" [class.status-item-error]="showConfigHints() && missingScenario()">
+            <div class="status-item" [class.status-item-error]="simulationService.showLaunchConfigHints() && missingScenario()">
                 <i class="fa-solid fa-flask status-icon"></i>
                 <div class="status-item-content">
                     <span class="status-item-label">Scénario</span>
@@ -11,7 +11,7 @@
                 </div>
             </div>
             <!-- Help bubble for missing scenario -->
-            <div class="config-hint-bubble" *ngIf="showConfigHints() && missingScenario()">
+            <div class="config-hint-bubble" *ngIf="simulationService.showLaunchConfigHints() && missingScenario()">
                 <i class="fa-solid fa-triangle-exclamation hint-icon"></i>
                 <div class="hint-content">
                     <span class="hint-title">Scénario requis</span>
@@ -22,7 +22,7 @@
                 </button>
             </div>
 
-            <div class="status-item" [class.status-item-error]="showConfigHints() && missingInfra()">
+            <div class="status-item" [class.status-item-error]="simulationService.showLaunchConfigHints() && missingInfra()">
                 <i class="fa-solid fa-layer-group status-icon"></i>
                 <div class="status-item-content">
                     <span class="status-item-label">Groupe infra.</span>
@@ -30,7 +30,7 @@
                 </div>
             </div>
             <!-- Help bubble for missing infrastructure -->
-            <div class="config-hint-bubble" *ngIf="showConfigHints() && missingInfra()">
+            <div class="config-hint-bubble" *ngIf="simulationService.showLaunchConfigHints() && missingInfra()">
                 <i class="fa-solid fa-triangle-exclamation hint-icon"></i>
                 <div class="hint-content">
                     <span class="hint-title">Groupe d'infrastructures requis</span>
@@ -42,12 +42,4 @@
             </div>
         </div>
     </div>
-
-    <!-- Launch button -->
-    <button id="run" class="hq-btn-green" [class.hq-btn-green-inactive]="!canLaunch()"
-        [disabled]="isLaunching()" (click)="onLaunchClick()">
-        <span *ngIf="isLaunching()" class="spinner-border spinner-border-sm me-2"></span>
-        <i *ngIf="!isLaunching()" class="fa-solid fa-play me-2"></i>
-        {{ isLaunching() ? 'Lancement...' : 'Lancer Simulation' }}
-    </button>
 </div>

--- a/client/src/app/components/simulation/simulation-launcher/simulation-launcher.spec.ts
+++ b/client/src/app/components/simulation/simulation-launcher/simulation-launcher.spec.ts
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
-import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { SimulationLauncher } from './simulation-launcher';
 import { SimulationService } from '@app/services/simulation-service';
@@ -42,9 +41,13 @@ const MOCK_GROUP: InfrastructureGroup = {
 const canLaunch = signal(false);
 const selectedScenario = signal<Scenario | null>(null);
 const selectedInfraGroup = signal<InfrastructureGroup | null>(null);
+const showLaunchConfigHints = signal(false);
 
 const mockSimulationService = {
   canLaunch,
+  showLaunchConfigHints,
+  requestLaunchFromMap: vi.fn(),
+  dismissLaunchHints: vi.fn(() => showLaunchConfigHints.set(false)),
   productionNodes: signal(null),
   openSourcesPanel$: new Subject<void>(),
   hasExportableData: signal(false),
@@ -58,13 +61,10 @@ const mockInfrastruturesService = {
   infraGroups: signal([] as InfrastructureGroup[]),
 };
 
-const mockRouter = { navigate: vi.fn() };
-
 const defaultProviders = [
   { provide: SimulationService, useValue: mockSimulationService },
   { provide: ScenariosService, useValue: mockScenariosService },
   { provide: InfrastruturesService, useValue: mockInfrastruturesService },
-  { provide: Router, useValue: mockRouter },
 ];
 
 describe('SimulationLauncher', () => {
@@ -72,6 +72,7 @@ describe('SimulationLauncher', () => {
     canLaunch.set(false);
     selectedScenario.set(null);
     selectedInfraGroup.set(null);
+    showLaunchConfigHints.set(false);
   });
 
   afterEach(() => vi.clearAllMocks());
@@ -83,48 +84,6 @@ describe('SimulationLauncher', () => {
     });
 
     expect(screen.getByText(/CONFIGURATION ACTIVE/i)).toBeInTheDocument();
-  });
-
-  describe('launchSimulation', () => {
-    it('should navigate to /simulation when the launch button is clicked', async () => {
-      const user = userEvent.setup();
-      canLaunch.set(true);
-
-      await render(SimulationLauncher, {
-        providers: defaultProviders,
-        schemas: [NO_ERRORS_SCHEMA],
-      });
-
-      await user.click(screen.getByRole('button', { name: /Lancer Simulation/i }));
-
-      expect(mockRouter.navigate).toHaveBeenCalledWith(['/simulation']);
-    });
-  });
-
-  describe('canLaunch signal', () => {
-    it('should render the launch button with disabled class when canLaunch is false', async () => {
-      canLaunch.set(false);
-
-      await render(SimulationLauncher, {
-        providers: defaultProviders,
-        schemas: [NO_ERRORS_SCHEMA],
-      });
-
-      const btn = screen.getByRole('button', { name: /Lancer Simulation/i });
-      expect(btn.classList.contains('hq-btn-green-inactive')).toBe(true);
-    });
-
-    it('should render the launch button without disabled class when canLaunch is true', async () => {
-      canLaunch.set(true);
-
-      await render(SimulationLauncher, {
-        providers: defaultProviders,
-        schemas: [NO_ERRORS_SCHEMA],
-      });
-
-      const btn = screen.getByRole('button', { name: /Lancer Simulation/i });
-      expect(btn.classList.contains('hq-btn-green-inactive')).toBe(false);
-    });
   });
 
   describe('selectedScenario display', () => {
@@ -178,39 +137,46 @@ describe('SimulationLauncher', () => {
   });
 
   describe('config hint bubbles', () => {
-    it('should show config hints when clicking launch with incomplete config', async () => {
-      const user = userEvent.setup();
-      canLaunch.set(false);
+    it('should show scenario hint when hints are active and scenario is missing', async () => {
+      showLaunchConfigHints.set(true);
       selectedScenario.set(null);
-      selectedInfraGroup.set(null);
-
-      const { fixture } = await render(SimulationLauncher, {
-        providers: defaultProviders,
-        schemas: [NO_ERRORS_SCHEMA],
-      });
-
-      await user.click(screen.getByRole('button', { name: /Lancer Simulation/i }));
-      fixture.detectChanges();
-
-      expect(fixture.componentInstance.showConfigHints()).toBe(true);
-      expect(mockRouter.navigate).not.toHaveBeenCalled();
-    });
-
-    it('should NOT show config hints when config is complete', async () => {
-      const user = userEvent.setup();
-      canLaunch.set(true);
-      selectedScenario.set(MOCK_SCENARIO);
       selectedInfraGroup.set(MOCK_GROUP);
 
-      const { fixture } = await render(SimulationLauncher, {
+      await render(SimulationLauncher, {
         providers: defaultProviders,
         schemas: [NO_ERRORS_SCHEMA],
       });
 
-      await user.click(screen.getByRole('button', { name: /Lancer Simulation/i }));
+      expect(screen.getByText(/Scénario requis/i)).toBeInTheDocument();
+    });
 
-      expect(fixture.componentInstance.showConfigHints()).toBe(false);
-      expect(mockRouter.navigate).toHaveBeenCalledWith(['/simulation']);
+    it('should show infra hint when hints are active and infra group is missing', async () => {
+      showLaunchConfigHints.set(true);
+      selectedScenario.set(MOCK_SCENARIO);
+      selectedInfraGroup.set(null);
+
+      await render(SimulationLauncher, {
+        providers: defaultProviders,
+        schemas: [NO_ERRORS_SCHEMA],
+      });
+
+      expect(screen.getByText(/Groupe d'infrastructures requis/i)).toBeInTheDocument();
+    });
+
+    it('should call dismissLaunchHints when dismissing a hint bubble', async () => {
+      const user = userEvent.setup();
+      showLaunchConfigHints.set(true);
+      selectedScenario.set(null);
+      selectedInfraGroup.set(MOCK_GROUP);
+
+      await render(SimulationLauncher, {
+        providers: defaultProviders,
+        schemas: [NO_ERRORS_SCHEMA],
+      });
+
+      await user.click(screen.getByRole('button', { name: /Fermer/i }));
+
+      expect(mockSimulationService.dismissLaunchHints).toHaveBeenCalled();
     });
 
     it('should report missingScenario and missingInfra correctly', async () => {

--- a/client/src/app/components/simulation/simulation-launcher/simulation-launcher.ts
+++ b/client/src/app/components/simulation/simulation-launcher/simulation-launcher.ts
@@ -1,23 +1,23 @@
-import { Component, computed, effect, signal, Signal } from '@angular/core';
+import { booleanAttribute, Component, computed, Input, Signal } from '@angular/core';
 import { SimulationService } from '@app/services/simulation-service';
 import { ScenariosService } from '@app/services/scenarios-service';
 import { InfrastruturesService } from '@app/services/infrastrutures-service';
 import { CommonModule } from '@angular/common';
 import { InfrastructureGroup } from '@app/models/infrastructure-group';
 import { Scenario } from '@app/models/scenario';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-simulation-launcher',
   imports: [CommonModule],
   templateUrl: './simulation-launcher.html',
   styleUrl: './simulation-launcher.css',
+  host: {
+    '[class.launcher--panel-footer]': 'panelFooter',
+  },
 })
 export class SimulationLauncher {
-  isLaunching = signal(false);
-  showConfigHints = signal(false);
+  @Input({ transform: booleanAttribute }) panelFooter = false;
 
-  canLaunch!: Signal<boolean>;
   selectedInfrastructure!: Signal<InfrastructureGroup | null>;
   selectedScenario!: Signal<Scenario | null>;
 
@@ -25,36 +25,15 @@ export class SimulationLauncher {
   missingInfra = computed(() => this.selectedInfrastructure() === null);
 
   constructor(
-    private simulationService: SimulationService,
+    public simulationService: SimulationService,
     private scenariosService: ScenariosService,
     private infrastructuresService: InfrastruturesService,
-    private router: Router,
   ) {
-    this.canLaunch = this.simulationService.canLaunch;
     this.selectedInfrastructure = this.infrastructuresService.selectedInfraGroup;
     this.selectedScenario = this.scenariosService.selectedScenario;
-
-    // Auto-dismiss hints when config becomes valid
-    effect(() => {
-      if (this.canLaunch()) {
-        this.showConfigHints.set(false);
-      }
-    });
-  }
-
-  launchSimulation() {
-    this.router.navigate(['/simulation']);
-  }
-
-  onLaunchClick() {
-    if (this.canLaunch()) {
-      this.launchSimulation();
-    } else {
-      this.showConfigHints.set(true);
-    }
   }
 
   dismissHints() {
-    this.showConfigHints.set(false);
+    this.simulationService.dismissLaunchHints();
   }
 }

--- a/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.css
+++ b/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.css
@@ -1,0 +1,3 @@
+:host {
+    display: block;
+}

--- a/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.html
+++ b/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.html
@@ -1,0 +1,10 @@
+<button
+    id="run"
+    type="button"
+    class="hq-btn-green"
+    [class.hq-btn-green-inactive]="!canLaunch()"
+    (click)="onLaunchClick()"
+>
+    <i class="fa-solid fa-play me-2"></i>
+    Lancer Simulation
+</button>

--- a/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.spec.ts
+++ b/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.spec.ts
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { SimulationPanelLaunchButton } from './simulation-panel-launch-button';
+import { SimulationService } from '@app/services/simulation-service';
+
+const canLaunch = signal(false);
+
+const mockSimulationService = {
+  canLaunch,
+  requestLaunchFromMap: vi.fn(),
+  showLaunchConfigHints: signal(false),
+  productionNodes: signal(null),
+  openSourcesPanel$: new Subject<void>(),
+};
+
+describe('SimulationPanelLaunchButton', () => {
+  beforeEach(() => {
+    canLaunch.set(false);
+    vi.clearAllMocks();
+  });
+
+  it('should call requestLaunchFromMap when clicked', async () => {
+    const user = userEvent.setup();
+    await render(SimulationPanelLaunchButton, {
+      providers: [{ provide: SimulationService, useValue: mockSimulationService }],
+      schemas: [NO_ERRORS_SCHEMA],
+    });
+
+    await user.click(screen.getByRole('button', { name: /Lancer Simulation/i }));
+
+    expect(mockSimulationService.requestLaunchFromMap).toHaveBeenCalled();
+  });
+
+  it('should render the launch button with inactive class when canLaunch is false', async () => {
+    canLaunch.set(false);
+
+    await render(SimulationPanelLaunchButton, {
+      providers: [{ provide: SimulationService, useValue: mockSimulationService }],
+      schemas: [NO_ERRORS_SCHEMA],
+    });
+
+    const btn = screen.getByRole('button', { name: /Lancer Simulation/i });
+    expect(btn.classList.contains('hq-btn-green-inactive')).toBe(true);
+  });
+
+  it('should render the launch button without inactive class when canLaunch is true', async () => {
+    canLaunch.set(true);
+
+    await render(SimulationPanelLaunchButton, {
+      providers: [{ provide: SimulationService, useValue: mockSimulationService }],
+      schemas: [NO_ERRORS_SCHEMA],
+    });
+
+    const btn = screen.getByRole('button', { name: /Lancer Simulation/i });
+    expect(btn.classList.contains('hq-btn-green-inactive')).toBe(false);
+  });
+});

--- a/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.ts
+++ b/client/src/app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button.ts
@@ -1,0 +1,21 @@
+import { Component, Signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SimulationService } from '@app/services/simulation-service';
+
+@Component({
+  selector: 'app-simulation-panel-launch-button',
+  imports: [CommonModule],
+  templateUrl: './simulation-panel-launch-button.html',
+  styleUrl: './simulation-panel-launch-button.css',
+})
+export class SimulationPanelLaunchButton {
+  canLaunch!: Signal<boolean>;
+
+  constructor(public simulationService: SimulationService) {
+    this.canLaunch = this.simulationService.canLaunch;
+  }
+
+  onLaunchClick(): void {
+    this.simulationService.requestLaunchFromMap();
+  }
+}

--- a/client/src/app/models/infrastructure-group.ts
+++ b/client/src/app/models/infrastructure-group.ts
@@ -1,3 +1,6 @@
+/** Groupe système « Infrastructures québécoises » (non modifiable, non persisté). */
+export const DEFAULT_INFRA_GROUP_ID = 1;
+
 export interface InfrastructureGroup {
     id: number;
     nom: string;

--- a/client/src/app/pages/map-page/map-page.css
+++ b/client/src/app/pages/map-page/map-page.css
@@ -72,6 +72,7 @@ div#main {
     left: 0;
 }
 
+
 .sources-panel-header {
     display: flex;
     align-items: center;
@@ -101,11 +102,33 @@ div#main {
 
 .sources-panel-content {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: 12px;
     display: flex;
     flex-direction: row;
     gap: 12px;
+}
+
+.sources-panel-footer {
+    flex-shrink: 0;
+    padding: 12px 16px 16px;
+    border-top: 1px solid #e9ecef;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 12px;
+    background: #fff;
+}
+
+.sources-panel-footer-config {
+    min-width: 0;
+    flex: 1;
+}
+
+.sources-panel-footer app-simulation-panel-launch-button {
+    transform: translateY(-7px);
 }
 
 .panel-column {
@@ -117,6 +140,7 @@ div#main {
 
 .panel-column-left {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
 }
 
@@ -134,6 +158,7 @@ app-simulation-results {
 
 /* ── Inner components inside the panel ── */
 app-simulation-launcher,
+app-simulation-panel-launch-button,
 app-infrastructure-selector,
 app-scenario-selector {
     display: flex;
@@ -144,6 +169,9 @@ app-scenario-selector {
 app-infrastructure-selector {
     flex: 1;
     min-height: 200px;
+}
+
+@media (max-width: 900px) {
 }
 
 @media (max-width: 480px) {

--- a/client/src/app/pages/map-page/map-page.html
+++ b/client/src/app/pages/map-page/map-page.html
@@ -19,14 +19,20 @@
         </div>
         <div class="sources-panel-content">
             <div class="panel-column panel-column-left">
-                <app-simulation-launcher />
                 <app-scenario-selector />
             </div>
             <div class="panel-column panel-column-right">
                 <app-infrastructure-selector />
             </div>
         </div>
+        <div class="sources-panel-footer">
+            <div class="sources-panel-footer-config">
+                <app-simulation-launcher panelFooter />
+            </div>
+            <app-simulation-panel-launch-button />
+        </div>
     </div>
+
 
     <!-- Full-screen simulation results (map / graphs) -->
     <app-simulation-results />

--- a/client/src/app/pages/map-page/map-page.spec.ts
+++ b/client/src/app/pages/map-page/map-page.spec.ts
@@ -1,12 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BehaviorSubject } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
 import { MapPage } from './map-page';
 import { TutorialService, TutorialState } from '@app/services/tutorial-service';
 import { InfraDetailService } from '@app/services/infra-detail-service';
+import { InfrastruturesService } from '@app/services/infrastrutures-service';
 
 vi.mock('leaflet.markercluster', () => ({}));
 
@@ -29,6 +30,10 @@ const mockInfraDetailService = {
     closeDetail: vi.fn(),
 };
 
+const mockInfrasService = {
+    selectedInfraGroup: signal<unknown>(null),
+};
+
 const STUB_TEMPLATE = `
   <button class="sources-toggle-btn" (click)="toggleSourcesPanel()">Sources d'Énergie</button>
   <div *ngIf="showSourcesPanel" class="sources-panel open" data-testid="sources-panel">Panel ouvert</div>
@@ -43,6 +48,7 @@ async function renderComponent() {
         providers: [
             { provide: TutorialService, useValue: mockTutorialService },
             { provide: InfraDetailService, useValue: mockInfraDetailService },
+            { provide: InfrastruturesService, useValue: mockInfrasService },
         ],
         schemas: [NO_ERRORS_SCHEMA],
     });

--- a/client/src/app/pages/map-page/map-page.ts
+++ b/client/src/app/pages/map-page/map-page.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, AfterViewInit } from '@angular/core';
 import { NavigationBar } from '@app/components/navigation-bar/navigation-bar';
 import { SimulationLauncher } from '@app/components/simulation/simulation-launcher/simulation-launcher';
+import { SimulationPanelLaunchButton } from '@app/components/simulation/simulation-panel-launch-button/simulation-panel-launch-button';
 import { ScenarioSelector } from '@app/components/scenario/scenario-selector/scenario-selector';
 import { InfrastructureSelector } from '@app/components/infrastructure/infrastructure-selector/infrastructure-selector';
 import { SimulationResults } from '@app/components/simulation/simulation-results/simulation-results';
@@ -8,20 +9,33 @@ import { TutorialOverlay } from '@app/components/tutorial-overlay/tutorial-overl
 import { CommonModule } from '@angular/common';
 import { TutorialService } from '@app/services/tutorial-service';
 import { InfraDetailService } from '@app/services/infra-detail-service';
+import { InfrastruturesService } from '@app/services/infrastrutures-service';
+import { DEFAULT_INFRA_GROUP_ID } from '@app/models/infrastructure-group';
 import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-map-page',
-  imports: [CommonModule, NavigationBar, SimulationLauncher, ScenarioSelector, InfrastructureSelector, SimulationResults, TutorialOverlay],
+  imports: [
+    CommonModule,
+    NavigationBar,
+    SimulationLauncher,
+    SimulationPanelLaunchButton,
+    ScenarioSelector,
+    InfrastructureSelector,
+    SimulationResults,
+    TutorialOverlay,
+  ],
   templateUrl: './map-page.html',
   styleUrl: './map-page.css',
 })
 export class MapPage implements OnDestroy, AfterViewInit {
+  readonly defaultInfraGroupId = DEFAULT_INFRA_GROUP_ID;
   showSourcesPanel = false;
   private tutorialSub: Subscription;
 
   constructor(
     public tutorialService: TutorialService,
+    public infrasService: InfrastruturesService,
     private infraDetailService: InfraDetailService,
   ) {
     this.tutorialSub = this.tutorialService.tutorialState$.subscribe((s) => {

--- a/client/src/app/services/graph-service.spec.ts
+++ b/client/src/app/services/graph-service.spec.ts
@@ -1,11 +1,5 @@
 vi.mock('plotly.js-dist-min', () => ({
-  default: {
-    newPlot: vi.fn(),
-    purge: vi.fn(),
-    downloadImage: vi.fn(),
-    register: vi.fn(),
-    setPlotConfig: vi.fn(),
-  },
+  __esModule: true,
   newPlot: vi.fn(),
   purge: vi.fn(),
   downloadImage: vi.fn(),

--- a/client/src/app/services/graph-service.spec.ts
+++ b/client/src/app/services/graph-service.spec.ts
@@ -1,10 +1,17 @@
 vi.mock('plotly.js-dist-min', () => ({
-  __esModule: true,
   newPlot: vi.fn(),
   purge: vi.fn(),
   downloadImage: vi.fn(),
   register: vi.fn(),
   setPlotConfig: vi.fn(),
+  default: {
+    newPlot: vi.fn(),
+    purge: vi.fn(),
+    downloadImage: vi.fn(),
+    register: vi.fn(),
+    setPlotConfig: vi.fn(),
+  },
+  __esModule: true,
 }));
 
 import { GraphService } from './graph-service';

--- a/client/src/app/services/infrastrutures-service.spec.ts
+++ b/client/src/app/services/infrastrutures-service.spec.ts
@@ -174,7 +174,7 @@ describe('InfrastruturesService', () => {
       expect(() => service.toggleInfra('eolienneparc', '5')).not.toThrow();
     });
 
-    it('should not change selection when the default Québec group is active', () => {
+    it('should create a new group when the default Québec group is active', () => {
       flushInitialHttpRequests();
       const def: InfrastructureGroup = {
         id: DEFAULT_INFRA_GROUP_ID,
@@ -189,7 +189,14 @@ describe('InfrastruturesService', () => {
 
       service.toggleInfra('eolienneparc', '1');
 
-      expect(service.selectedInfraGroup()?.parc_eoliens).toEqual(['1']);
+      // It should have called createElement for the new group
+      expect(mockStorageService.createElement).toHaveBeenCalledWith(
+        'harmoniq_local_infra_groups',
+        expect.objectContaining({ nom: "Groupe d'infrastructure 1" }),
+      );
+      // And the new selected group should have the change
+      expect(service.selectedInfraGroup()?.nom).toBe("Groupe d'infrastructure 1");
+      expect(service.selectedInfraGroup()?.parc_eoliens).toEqual([]);
     });
   });
 
@@ -245,7 +252,7 @@ describe('InfrastruturesService', () => {
   });
 
   describe('setInfrasForType', () => {
-    it('should not run when the default Québec group is selected', () => {
+    it('should create a new group when the default Québec group is selected', () => {
       flushInitialHttpRequests();
       service.selectedInfraGroup.set({
         id: DEFAULT_INFRA_GROUP_ID,
@@ -259,7 +266,10 @@ describe('InfrastruturesService', () => {
 
       service.setInfrasForType('eolienneparc', []);
 
-      expect(mockStorageService.updateElement).not.toHaveBeenCalled();
+      expect(mockStorageService.createElement).toHaveBeenCalledWith(
+        'harmoniq_local_infra_groups',
+        expect.objectContaining({ nom: "Groupe d'infrastructure 1" }),
+      );
     });
   });
 

--- a/client/src/app/services/infrastrutures-service.spec.ts
+++ b/client/src/app/services/infrastrutures-service.spec.ts
@@ -30,7 +30,7 @@ import { InfrastruturesService } from './infrastrutures-service';
 import { OpenApiService } from './open-api-service';
 import { LocalStorageService } from './local-storage-service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { InfrastructureGroup } from '@app/models/infrastructure-group';
+import { DEFAULT_INFRA_GROUP_ID, InfrastructureGroup } from '@app/models/infrastructure-group';
 
 const INFRA_TYPES = ['hydro', 'eolienneparc', 'solaire', 'thermique', 'nucleaire'];
 const API_BASE = 'http://localhost:5000/api';
@@ -65,6 +65,7 @@ describe('InfrastruturesService', () => {
       createElement: vi.fn().mockImplementation((_key: string, el: any) => ({ ...el, id: 100 })),
       updateElement: vi.fn(),
       deleteElement: vi.fn(),
+      saveObject: vi.fn(),
     };
     mockModalService = {
       open: vi.fn().mockReturnValue({
@@ -172,6 +173,24 @@ describe('InfrastruturesService', () => {
 
       expect(() => service.toggleInfra('eolienneparc', '5')).not.toThrow();
     });
+
+    it('should not change selection when the default Québec group is active', () => {
+      flushInitialHttpRequests();
+      const def: InfrastructureGroup = {
+        id: DEFAULT_INFRA_GROUP_ID,
+        nom: 'Infrastructures québécoises',
+        parc_eoliens: ['1'],
+        parc_solaires: [],
+        central_hydroelectriques: [],
+        central_thermique: [],
+        central_nucleaire: [],
+      };
+      service.selectedInfraGroup.set(def);
+
+      service.toggleInfra('eolienneparc', '1');
+
+      expect(service.selectedInfraGroup()?.parc_eoliens).toEqual(['1']);
+    });
   });
 
   describe('createInfraGroup', () => {
@@ -222,6 +241,25 @@ describe('InfrastruturesService', () => {
       service.deleteInfraGroup(MOCK_INFRA_GROUP);
 
       expect(service.selectedInfraGroup()).toBeNull();
+    });
+  });
+
+  describe('setInfrasForType', () => {
+    it('should not run when the default Québec group is selected', () => {
+      flushInitialHttpRequests();
+      service.selectedInfraGroup.set({
+        id: DEFAULT_INFRA_GROUP_ID,
+        nom: 'Infrastructures québécoises',
+        parc_eoliens: ['1'],
+        parc_solaires: [],
+        central_hydroelectriques: [],
+        central_thermique: [],
+        central_nucleaire: [],
+      });
+
+      service.setInfrasForType('eolienneparc', []);
+
+      expect(mockStorageService.updateElement).not.toHaveBeenCalled();
     });
   });
 

--- a/client/src/app/services/infrastrutures-service.ts
+++ b/client/src/app/services/infrastrutures-service.ts
@@ -234,8 +234,13 @@ export class InfrastruturesService {
   }
 
   toggleInfra(type: string, infraId: string) {
-    const infraGroup: any = this.selectedInfraGroup();
-    if (!infraGroup) return;
+    const currentGroup: any = this.selectedInfraGroup();
+    if (!currentGroup) return;
+
+    const isDefault = this.isDefaultInfraGroup(currentGroup);
+    const infraGroup = isDefault
+      ? { ...currentGroup, id: 0, nom: this._getNextDefaultGroupName() }
+      : { ...currentGroup };
 
     const key = typeKeyMap[type];
     if (!key) return;
@@ -249,21 +254,35 @@ export class InfrastruturesService {
       isActive = true;
     }
 
-    this.selectedInfraGroup.set({ ...infraGroup });
-    this._persistSelectedGroup();
+    if (isDefault) {
+      this.createInfraGroup(infraGroup);
+    } else {
+      this.selectedInfraGroup.set(infraGroup);
+      this._persistSelectedGroup();
+    }
+
     this.infraToggled.emit({ type, id: infraId, isActive });
   }
 
   setInfrasForType(type: string, infrasIds: any[]) {
-    const infraGroup: any = this.selectedInfraGroup();
-    if (!infraGroup) return;
+    const currentGroup: any = this.selectedInfraGroup();
+    if (!currentGroup) return;
+
+    const isDefault = this.isDefaultInfraGroup(currentGroup);
+    const infraGroup = isDefault
+      ? { ...currentGroup, id: 0, nom: this._getNextDefaultGroupName() }
+      : { ...currentGroup };
 
     const key = typeKeyMap[type];
     if (!key) return;
     infraGroup[key] = infrasIds;
 
-    this.selectedInfraGroup.set({ ...infraGroup });
-    this._persistSelectedGroup();
+    if (isDefault) {
+      this.createInfraGroup(infraGroup);
+    } else {
+      this.selectedInfraGroup.set(infraGroup);
+      this._persistSelectedGroup();
+    }
   }
 
   refreshInfraGroups() {
@@ -324,8 +343,20 @@ export class InfrastruturesService {
 
   private _persistSelectedGroup() {
     const group = this.selectedInfraGroup();
-    if (group)
+    if (group && group.id !== DEFAULT_INFRA_GROUP_ID)
       this.storageService.updateElement(INFRA_GROUPS_KEY, group);
+  }
+
+  private _getNextDefaultGroupName(): string {
+    const baseName = "Groupe d'infrastructure";
+    const groups = this.infraGroups();
+    let index = 1;
+    let name = `${baseName} ${index}`;
+    while (groups.some(g => g.nom === name)) {
+      index++;
+      name = `${baseName} ${index}`;
+    }
+    return name;
   }
 
   private getDefaultInfraGroup(): InfrastructureGroup {

--- a/client/src/app/services/infrastrutures-service.ts
+++ b/client/src/app/services/infrastrutures-service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { computed, EventEmitter, Injectable, signal } from '@angular/core';
-import { InfrastructureGroup } from '@app/models/infrastructure-group';
+import { DEFAULT_INFRA_GROUP_ID, InfrastructureGroup } from '@app/models/infrastructure-group';
 import { environment } from 'environments/environment';
 import { OpenApiService } from './open-api-service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
@@ -133,7 +133,7 @@ export class InfrastruturesService {
 
     this.infrasContainer.forEach((container) => {
       container.loaded.subscribe(() => {
-        if (this.selectedInfraGroup() != null && this.selectedInfraGroup()?.id !== 1)
+        if (this.selectedInfraGroup() != null && this.selectedInfraGroup()?.id !== DEFAULT_INFRA_GROUP_ID)
           return;
         this.selectedInfraGroup.set(this.getDefaultInfraGroup());
       });
@@ -229,18 +229,23 @@ export class InfrastruturesService {
     return infraGroup[key].includes(infraId);
   }
 
+  isDefaultInfraGroup(group: InfrastructureGroup | null | undefined): boolean {
+    return group != null && group.id === DEFAULT_INFRA_GROUP_ID;
+  }
+
   toggleInfra(type: string, infraId: string) {
     const infraGroup: any = this.selectedInfraGroup();
     if (!infraGroup) return;
 
     const key = typeKeyMap[type];
+    if (!key) return;
 
     let isActive = false;
     if (infraGroup[key].includes(infraId)) {
       infraGroup[key] = infraGroup[key].filter((id: string) => id !== infraId);
       isActive = false;
     } else {
-      infraGroup[key].push(infraId);
+      infraGroup[key] = [...infraGroup[key], infraId];
       isActive = true;
     }
 
@@ -264,6 +269,14 @@ export class InfrastruturesService {
   refreshInfraGroups() {
     const groups = this.storageService.loadElements<InfrastructureGroup>(INFRA_GROUPS_KEY);
     this.localInfraGroups.set(groups);
+
+    const selected = this.selectedInfraGroup();
+    if (selected && selected.id !== DEFAULT_INFRA_GROUP_ID) {
+      const updated = groups.find((g) => g.id === selected.id);
+      if (updated) {
+        this.selectedInfraGroup.set({ ...updated });
+      }
+    }
   }
 
   createInfraGroup(group: InfrastructureGroup) {

--- a/client/src/app/services/infrastrutures-service.ts
+++ b/client/src/app/services/infrastrutures-service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { computed, EventEmitter, Injectable, signal } from '@angular/core';
+import { computed, EventEmitter, Injectable, signal, inject, Injector } from '@angular/core';
 import { DEFAULT_INFRA_GROUP_ID, InfrastructureGroup } from '@app/models/infrastructure-group';
 import { environment } from 'environments/environment';
 import { OpenApiService } from './open-api-service';
@@ -15,7 +15,6 @@ import { LocalStorageService } from './local-storage-service';
 import { isFictionalHydro } from '@app/data/fictional-hydro-names';
 import { firstValueFrom, Subject } from 'rxjs';
 import { SnackbarService } from './snackbar-service';
-import { Injector } from '@angular/core';
 import { InfraDetailService } from './infra-detail-service';
 
 // Hack pcq le code etait ass et j'ai la flemme
@@ -116,6 +115,8 @@ export class InfrastruturesService {
   private defaultInfraGroup = computed(() => this.getDefaultInfraGroup());
   infraGroups = computed(() => [this.defaultInfraGroup(), ...this.localInfraGroups()])
 
+  private injector = inject(Injector);
+
   infraToggled = new EventEmitter<{ type: string, id: string, isActive: boolean }>();
   /**
  * Puissance garantie (MW) du groupe d'infrastructures actif.
@@ -161,7 +162,6 @@ export class InfrastruturesService {
     private openApiService: OpenApiService,
     private storageService: LocalStorageService,
     private snackbarService: SnackbarService,
-    private injector: Injector,
   ) {
     this.refreshInfraGroups();
     this.selectedInfraGroup.set(this.getDefaultInfraGroup());
@@ -195,10 +195,13 @@ export class InfrastruturesService {
       if (!result) return;
 
       const localInfra = this.storageService.createElement(`${INFRA_KEY}_${type}`, { ...result, isUserCreated: true });
+      const idStr = localInfra.id.toString();
       this.infrasContainer.get(type)?.addLocal(localInfra);
 
+      this.toggleInfra(type, idStr);
+
       const detailService = this.injector.get(InfraDetailService);
-      detailService.openDetail(type, localInfra.id.toString());
+      detailService.openDetail(type, idStr);
     }).catch(() => { });
   }
 
@@ -306,16 +309,8 @@ export class InfrastruturesService {
       this.storageService.saveObject(FICTIONAL_HYDRO_IDS_KEY, addedIds);
     }
 
-    // Ajouter au groupe sélectionné
-    const group: any = this.selectedInfraGroup();
-    if (group) {
-      const key = 'central_hydroelectriques';
-      if (!group[key].includes(id.toString())) {
-        group[key].push(id.toString());
-        this.selectedInfraGroup.set({ ...group });
-        this._persistSelectedGroup();
-      }
-    }
+    // Ajouter au groupe sélectionné (utilise toggleInfra pour gérer le branching)
+    this.toggleInfra('hydro', id.toString());
   }
 
   /** Retire un barrage fictif de la carte et du groupe d'infras. */

--- a/client/src/app/services/infrastrutures-service.ts
+++ b/client/src/app/services/infrastrutures-service.ts
@@ -13,6 +13,7 @@ import { ThermalPowerPlantFactory } from '@app/models/infras/thermal-power-plant
 import { NuclearPowerPlantFactory } from '@app/models/infras/nuclear-power-plant';
 import { LocalStorageService } from './local-storage-service';
 import { Subject } from 'rxjs';
+import { SnackbarService } from './snackbar-service';
 
 // Hack pcq le code etait ass et j'ai la flemme
 const typeKeyMap: Record<string, string> = {
@@ -121,6 +122,7 @@ export class InfrastruturesService {
     private modalService: NgbModal,
     private openApiService: OpenApiService,
     private storageService: LocalStorageService,
+    private snackbarService: SnackbarService,
   ) {
     this.refreshInfraGroups();
     this.selectedInfraGroup.set(this.getDefaultInfraGroup());
@@ -256,6 +258,11 @@ export class InfrastruturesService {
 
     if (isDefault) {
       this.createInfraGroup(infraGroup);
+      this.snackbarService.show(
+        "Nouveau groupe d'infrastructures",
+        `Le groupe « ${infraGroup.nom} » a été créé car le groupe Infrastructures québécoises ne peut pas être modifié.`,
+        'info'
+      );
     } else {
       this.selectedInfraGroup.set(infraGroup);
       this._persistSelectedGroup();
@@ -279,6 +286,11 @@ export class InfrastruturesService {
 
     if (isDefault) {
       this.createInfraGroup(infraGroup);
+      this.snackbarService.show(
+        "Nouveau groupe d'infrastructures",
+        `Le groupe « ${infraGroup.nom} » a été créé car le groupe Infrastructures québécoises ne peut pas être modifié.`,
+        'info'
+      );
     } else {
       this.selectedInfraGroup.set(infraGroup);
       this._persistSelectedGroup();

--- a/client/src/app/services/simulation-service.spec.ts
+++ b/client/src/app/services/simulation-service.spec.ts
@@ -20,6 +20,7 @@ vi.mock('leaflet', () => ({
 }));
 
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { SimulationService } from './simulation-service';
@@ -58,6 +59,7 @@ const MOCK_INFRA_GROUP: InfrastructureGroup = {
 
 describe('SimulationService', () => {
   let service: SimulationService;
+  let mockRouter: { navigate: ReturnType<typeof vi.fn> };
   let mockScenariosService: Partial<ScenariosService>;
   let mockInfrastruturesService: Partial<InfrastruturesService>;
   let mockDemandeSankeyService: Partial<DemandeSankeyGraphService>;
@@ -66,6 +68,8 @@ describe('SimulationService', () => {
   let mockSnackbarService: Partial<SnackbarService>;
 
   beforeEach(() => {
+    mockRouter = { navigate: vi.fn() };
+
     const selectedScenarioSignal = signal<Scenario | null>(null);
     mockScenariosService = {
       selectedScenario: selectedScenarioSignal,
@@ -109,6 +113,7 @@ describe('SimulationService', () => {
         { provide: SimulationTemporalGraphService, useValue: mockSimulationTemporalService },
         { provide: SimulationStepService, useValue: mockStepService },
         { provide: SnackbarService, useValue: mockSnackbarService },
+        { provide: Router, useValue: mockRouter },
         provideHttpClient(),
         provideHttpClientTesting(),
       ],

--- a/client/src/app/services/simulation-service.ts
+++ b/client/src/app/services/simulation-service.ts
@@ -1,4 +1,5 @@
 import { Injectable, computed, effect, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
 import { ScenariosService } from './scenarios-service';
 import { InfrastruturesService } from './infrastrutures-service';
 import { HttpClient } from '@angular/common/http';
@@ -25,6 +26,8 @@ export class SimulationService {
 
     openSourcesPanel$ = new Subject<void>();
     productionNodes = signal<ProductionNode[] | null>(null);
+    /** Shown when the user clicks « Lancer Simulation » with an incomplete map configuration. */
+    showLaunchConfigHints = signal(false);
 
     private simulationStepService = inject(SimulationStepService);
     step = computed(() => this.simulationStepService.currentStepName());
@@ -39,7 +42,14 @@ export class SimulationService {
         private simulationCo2GraphService: SimulationCo2GraphService,
         private simulationAnalysisGraphService: SimulationAnalysisGraphService,
         private snackbar: SnackbarService,
+        private router: Router,
     ) {
+        effect(() => {
+            if (this.canLaunch()) {
+                this.showLaunchConfigHints.set(false);
+            }
+        });
+
         effect(() => {
             this.scenariosService.selectedScenario(); // track scenario changes
             this.simulationTemporalGraphService.cachedScenarioId = undefined;
@@ -75,6 +85,19 @@ export class SimulationService {
             this.simulationAnalysisGraphService.reset();
             this.productionNodes.set(null);
         });
+    }
+
+    /** Navigate to the simulation page, or surface configuration hints on the map panel. */
+    requestLaunchFromMap(): void {
+        if (this.canLaunch()) {
+            this.router.navigate(['/simulation']);
+        } else {
+            this.showLaunchConfigHints.set(true);
+        }
+    }
+
+    dismissLaunchHints(): void {
+        this.showLaunchConfigHints.set(false);
     }
 
     private getInfraScenarioPayload(type: string, infraId: number) {

--- a/client/src/app/services/tutorial-service.ts
+++ b/client/src/app/services/tutorial-service.ts
@@ -132,7 +132,7 @@ export class TutorialService {
             title: 'Lancement',
             icon: 'fa-solid fa-play',
             description: 'Vérifiez le scénario et le groupe actifs, puis lancez la simulation depuis ce panneau pour voir les résultats.',
-            targetSelector: 'app-simulation-launcher',
+            targetSelector: 'app-simulation-panel-launch-button',
             position: 'right',
         },
         {


### PR DESCRIPTION
- Changement de la disposition de l’information dans le panneau source d’énergie
- Changement au comportement de la sélection des infrastructures

1. Les infrastructures québécoises ne peuvent plus être sélectionnées ou désélectionnées (le groupe « infrastructures québécoises » ne peut plus être modifié).

2. Les infrastructures québécoises sont incluses par défaut dans tout nouveau groupe d’infrastructures créé par l’utilisateur

- Ajout d’un message quand le groupe « infrastructures québécoises » expliquant que ce groupe ne peut pas être modifié et qu’il doit faire partie de toute simulation.